### PR TITLE
Add MOI Disjunction Set Representation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.0"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 JuMP = "1"

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -289,7 +289,6 @@ end
 ################################################################################
 #                              SOLUTION METHODS
 ################################################################################
-
 """
     AbstractSolutionMethod
 
@@ -364,6 +363,35 @@ end
 A type for using indicator constraint approach for linear disjunctive constraints.
 """
 struct Indicator <: AbstractReformulationMethod end
+
+"""
+    MOIDisjunction <: AbstractReformulationMethod
+
+A reformulation type for reformulating disjunctions into their MathOptInterface 
+set representations [`DisjucntionSet`](@ref) which are then added to the model.
+"""
+struct MOIDisjunction <: AbstractReformulationMethod end
+
+"""
+    DisjunctionSet{S} <: MOI.AbstractVectorSet
+
+A MathOptInterface set for representing disjunctions in the format vector of 
+functions in set to enable:
+```julia
+@constraint(model, [funcs...] in DisjunctionSet(n, idxs, sets))
+```
+where the vector of functions `funcs` is a flattened version of all the disjunct 
+constraint functions where the indicator variable is listed first, `n` is the 
+length of `[funcs...]`, `idxs` is a vector of the indices tracking where each 
+disjunct begins (i.e., it stores the indices of the indicator variables in 
+`[funcs...]`), and `sets` is a uses a nested vector structure of the MOI sets 
+that correspond to all the disjunct constraint functions.
+"""
+struct DisjunctionSet{S} <: _MOI.AbstractVectorSet 
+    dimension::Int
+    disjunct_indices::Vector{Int}
+    constraint_sets::Vector{Vector{S}}
+end
 
 ################################################################################
 #                              GDP Data

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -373,7 +373,7 @@ set representations [`DisjucntionSet`](@ref) which are then added to the model.
 struct MOIDisjunction <: AbstractReformulationMethod end
 
 """
-    DisjunctionSet{S} <: MOI.AbstractVectorSet
+    DisjunctionSet{S <: MOI.AbstractSet} <: MOI.AbstractVectorSet
 
 A MathOptInterface set for representing disjunctions in the format vector of 
 functions in set to enable:
@@ -384,10 +384,10 @@ where the vector of functions `funcs` is a flattened version of all the disjunct
 constraint functions where the indicator variable is listed first, `n` is the 
 length of `[funcs...]`, `idxs` is a vector of the indices tracking where each 
 disjunct begins (i.e., it stores the indices of the indicator variables in 
-`[funcs...]`), and `sets` is a uses a nested vector structure of the MOI sets 
+`[funcs...]`), and `sets` is a uses a vector of vectors structure for the MOI sets 
 that correspond to all the disjunct constraint functions.
 """
-struct DisjunctionSet{S} <: _MOI.AbstractVectorSet 
+struct DisjunctionSet{S <: _MOI.AbstractSet} <: _MOI.AbstractVectorSet 
     dimension::Int
     disjunct_indices::Vector{Int}
     constraint_sets::Vector{Vector{S}}

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -1,0 +1,50 @@
+################################################################################
+#                               UTILITY METHODS
+################################################################################
+# Requred for extensions to MOI.AbstractVectorSet
+function _MOI.Utilities.set_dot(x::AbstractVector, y::AbstractVector, set::DisjunctionSet)
+    return LinearAlgebra.dot(x, y) # TODO figure out what we should actually do here
+end
+
+# TODO create a bridge for `DisjunctionSet`
+
+# TODO create helper method to unpack DisjunctionSet at the MOI side of things
+
+################################################################################
+#                            REFRORMULATION METHODS
+################################################################################
+# Helper methods to handle recursively flattening the disjuncts
+function _constr_set!(funcs, con::JuMP.AbstractConstraint)
+    append!(funcs, JuMP.jump_function(con))
+    return JuMP.moi_set(con)
+end
+function _constr_set!(funcs, con::Disjunction)
+    inner_funcs, set = _disjunction_to_set(con)
+    append!(funcs, inner_funcs)
+    return set
+end
+
+# Create the vectors needed for a disjunction vector constraint
+function _disjunction_to_set(d::Disjunction)
+    funcs = JuMP.AbstractJuMPScalar[]
+    sets = [] # TODO add type 
+    d_idxs = Int[]
+    for lvref in d.indicators
+        model = JuMP.owner_model(lvref)
+        push!(funcs, _indicator_to_binary(model)[lvref])
+        push!(d_idxs, length(funcs))
+        crefs = _indicator_to_constraints(model)[lvref]
+        push!(sets, [_constr_set!(funcs, JuMP.constraint_object(cref)) for cref in crefs])
+    end
+    return funcs, DisjunctionSet(length(funcs), d_idxs, sets)
+end
+
+# Extend the disjunction reformulation
+function reformulate_disjunction(
+    model::JuMP.Model, 
+    d::Disjunction, 
+    ::MOIDisjunction
+    )
+    funcs, set = _disjunction_to_set(d)
+    return [JuMP.VectorConstraint(funcs, set, JuMP.VectorShape())]
+end

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -34,7 +34,7 @@ function _disjunction_to_set(d::Disjunction)
         push!(funcs, _indicator_to_binary(model)[lvref])
         push!(d_idxs, length(funcs))
         crefs = _indicator_to_constraints(model)[lvref]
-        push!(sets, [_constr_set!(funcs, JuMP.constraint_object(cref)) for cref in crefs])
+        push!(sets, map(c -> _constr_set!(funcs, JuMP.constraint_object(c)), crefs))
     end
     # convert the `sets` type to be concrete if possible (TODO benchmark if this is worth it)
     SetType = typeof(first(sets))


### PR DESCRIPTION
This adds the `MOIDisjunction` reformulation method which transforms disjunctions in vector constraints that use `DisjunctionSet`. This enables us to pass disjunctions directly down to the MOI level.